### PR TITLE
feat(storybook): setup chromatic

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v3.0.0
         name: Install pnpm

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -132,6 +132,21 @@ jobs:
         run: |
           pnpm run --if-present test
 
+  visual-regression:
+    runs-on: ubuntu-latest
+    needs: install
+
+    steps:
+      - name: Publish to Chromatic
+        uses: chromaui/action@v11
+        if: |
+          github.event.pull_request.draft == false &&
+          github.actor != 'dependabot[bot]'
+        with:
+          autoAcceptChanges: main
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: packages/storybook/dist/
+
   publish-website:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -98,6 +98,16 @@ jobs:
         run: |
           pnpm run --if-present test-build
 
+      - name: "Publish to Chromatic"
+        uses: chromaui/action@v11
+        if: |
+          github.event.pull_request.draft == false &&
+          github.actor != 'dependabot[bot]'
+        with:
+          autoAcceptChanges: main
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: packages/storybook/dist/
+
       - name: "Retain build artifact: storybook"
         uses: actions/upload-artifact@v4.3.1
         with:
@@ -131,27 +141,6 @@ jobs:
       - name: "Continuous Integration: test"
         run: |
           pnpm run --if-present test
-
-  visual-regression:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: "Restore build artifact: Storybook"
-        uses: actions/download-artifact@v4.1.4
-        with:
-          name: storybook
-          path: packages/storybook/dist/
-
-      - name: Publish to Chromatic
-        uses: chromaui/action@v11
-        if: |
-          github.event.pull_request.draft == false &&
-          github.actor != 'dependabot[bot]'
-        with:
-          autoAcceptChanges: main
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: packages/storybook/dist/
 
   publish-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -134,7 +134,7 @@ jobs:
 
   visual-regression:
     runs-on: ubuntu-latest
-    needs: install
+    needs: build
 
     steps:
       - name: Publish to Chromatic

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           autoAcceptChanges: main
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: packages/storybook/
+          storybookBuildDir: packages/storybook/src/
 
   publish-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           autoAcceptChanges: main
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: packages/storybook/dist/
+          storybookBuildDir: packages/storybook/
 
   publish-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -137,6 +137,12 @@ jobs:
     needs: build
 
     steps:
+      - name: "Restore build artifact: Storybook"
+        uses: actions/download-artifact@v4.1.4
+        with:
+          name: storybook
+          path: packages/storybook/dist/
+
       - name: Publish to Chromatic
         uses: chromaui/action@v11
         if: |

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           autoAcceptChanges: main
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: packages/storybook/src/
+          storybookBuildDir: packages/storybook/dist/
 
   publish-website:
     runs-on: ubuntu-latest

--- a/packages/storybook/config/main.ts
+++ b/packages/storybook/config/main.ts
@@ -11,7 +11,6 @@ const config: StorybookConfig = {
     '@storybook/addon-actions',
     '@storybook/addon-interactions',
     '@storybook/addon-links',
-    '@chromatic-com/storybook',
   ],
   framework: {
     name: '@storybook/react-vite',
@@ -22,6 +21,12 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: true,
+  },
+  managerHead(head) {
+    return `
+      ${head}
+      <style>div[data-item-id$="--visual"] { display: none; }</style>
+    `;
   },
   features: {},
   staticDirs: ['../../../proprietary/assets/src'],

--- a/packages/storybook/config/main.ts
+++ b/packages/storybook/config/main.ts
@@ -4,12 +4,14 @@ const config: StorybookConfig = {
   stories: ['../src/**/*stories.@(js|jsx|ts|tsx)', '../src/**/*.mdx'],
   addons: [
     '@storybook/addon-a11y',
+    '@storybook/addon-backgrounds',
     '@storybook/addon-controls',
     '@storybook/addon-docs',
     '@storybook/addon-viewport',
     '@storybook/addon-actions',
     '@storybook/addon-interactions',
     '@storybook/addon-links',
+    '@chromatic-com/storybook',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/packages/storybook/config/preview-head.html
+++ b/packages/storybook/config/preview-head.html
@@ -1,1 +1,6 @@
 <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+<style>
+  div[data-item-id$="--visual"] {
+    display: none;
+  }
+</style>

--- a/packages/storybook/config/preview-head.html
+++ b/packages/storybook/config/preview-head.html
@@ -1,6 +1,1 @@
 <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-<style>
-  div[data-item-id$="--visual"] {
-    display: none;
-  }
-</style>

--- a/packages/storybook/config/preview.tsx
+++ b/packages/storybook/config/preview.tsx
@@ -22,7 +22,7 @@ const preview: Preview = {
           <div style={{ padding: '1rem' }}>
             <Story />
           </div>
-          <div className="lux-theme--dark" style={{ padding: '1rem', backgroundColor: 'black' }}>
+          <div className="lux-theme--dark" style={{ padding: '1rem', background: 'black', color: 'white' }}>
             <Story />
           </div>
         </div>
@@ -30,8 +30,37 @@ const preview: Preview = {
     },
   ],
   parameters: {
+    backgrounds: {
+      default: 'mode',
+      values: [
+        {
+          name: 'mode',
+          value: 'var(--lux-color-background-default)',
+        },
+        {
+          /*
+          Deliberately provide a background which we'd never use in production.
+          This helps us identify the component boundaries. Use purple because
+          it's Aline's favorite color.
+          */
+          name: 'boundaries',
+          value: 'rebeccapurple',
+        },
+        {
+          name: 'transparent',
+          value:
+            'fixed repeating-conic-gradient(#CCC 0% 25%, var(--lux-color-background-default) 0% 50%) 50% / 20px 20px',
+        },
+      ],
+    },
+    chromatic: {
+      disable: true,
+      // Enable on story level. Not every story needs to be tested.
+      disableSnapshot: true,
+    },
     controls: { expanded: false },
     options: {
+      showPanel: true,
       panelPosition: 'bottom',
     },
   },

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,8 @@
 {
   "version": "1.0.0-alpha.0",
-  "author": "Community for NL Design System",
+  "author": {
+    "name": "Community for NL Design System"
+  },
   "description": "Storybook based on the NL Design System architecture",
   "license": "EUPL-1.2",
   "name": "@lux/storybook",
@@ -10,16 +12,18 @@
   "private": true,
   "repository": {
     "type": "git+ssh",
-    "url": "git@github.com:nl-design-system/lux.git"
+    "url": "git+ssh://git@github.com/nl-design-system/lux.git"
   },
   "scripts": {
     "build": "storybook build --output-dir dist/ --config-dir config/",
     "clean": "rimraf dist/",
     "lint-build": "tsc --noEmit --project tsconfig.json",
     "storybook": "storybook dev --config-dir config/ --port 6006",
-    "build-storybook": "storybook build --config-dir config/ --output-dir dist/"
+    "build-storybook": "storybook build --config-dir config/ --output-dir dist/",
+    "chromatic": "npx chromatic --project-token=chpt_f32f454ec222a1c"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "1.3.3",
     "@lux/assets": "workspace:*",
     "@lux/components-css": "workspace:*",
     "@lux/design-tokens": "workspace:*",
@@ -28,6 +32,7 @@
     "@lux/web-components-stencil": "workspace:*",
     "@storybook/addon-a11y": "8.0.8",
     "@storybook/addon-actions": "8.0.8",
+    "@storybook/addon-backgrounds": "8.0.8",
     "@storybook/addon-docs": "8.0.8",
     "@storybook/addon-interactions": "8.0.8",
     "@storybook/addon-links": "8.0.8",
@@ -43,6 +48,7 @@
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",
     "@vitejs/plugin-react": "4.2.1",
+    "chromatic": "11.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "require-from-string": "2.0.2",
@@ -54,5 +60,9 @@
   "dependencies": {
     "@storybook/addon-controls": "8.0.8",
     "@storybook/blocks": "8.0.8"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/nl-design-system/lux/issues"
+  },
+  "homepage": "https://github.com/nl-design-system/lux#readme"
 }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
     "lint-build": "tsc --noEmit --project tsconfig.json",
     "storybook": "storybook dev --config-dir config/ --port 6006",
     "build-storybook": "storybook build --config-dir config/ --output-dir dist/",
-    "chromatic": "npx chromatic --project-token=chpt_f32f454ec222a1c"
+    "chromatic": "chromatic"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "1.3.3",

--- a/packages/storybook/src/utils/createVisualRegressionStory.tsx
+++ b/packages/storybook/src/utils/createVisualRegressionStory.tsx
@@ -1,0 +1,42 @@
+import { StoryObj } from '@storybook/react';
+import { CSSProperties, PropsWithChildren, ReactElement } from 'react';
+
+type VisualRegressionRenderFn = () => ReactElement<void, any>;
+interface CreateVisualRegressionStoryFn {
+  // eslint-disable-next-line no-unused-vars
+  (render: VisualRegressionRenderFn): StoryObj;
+}
+
+export const createVisualRegressionStory: CreateVisualRegressionStoryFn = (
+  render: VisualRegressionRenderFn,
+): StoryObj => {
+  return {
+    parameters: {
+      options: {
+        showPanel: false,
+      },
+      a11y: { disable: true },
+      interactions: { disable: true },
+      actions: { disable: true },
+      controls: { disable: true },
+      backgrounds: { default: 'transparent' },
+      chromatic: {
+        disable: false,
+        disableSnapshot: false,
+      },
+    },
+    render,
+  };
+};
+
+export const VisualRegressionWrapper = ({ children }: PropsWithChildren) => {
+  const wrapperStyle: CSSProperties = {
+    backgroundColor: '',
+    display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
+    gap: '16px 32px',
+  };
+
+  return <div style={wrapperStyle}>{children}</div>;
+};

--- a/packages/storybook/src/utils/createVisualRegressionStory.tsx
+++ b/packages/storybook/src/utils/createVisualRegressionStory.tsx
@@ -7,6 +7,30 @@ interface CreateVisualRegressionStoryFn {
   (render: VisualRegressionRenderFn): StoryObj;
 }
 
+/**
+ * Create a story which will be used by Chromatic, but is invisible to the user. You can still navigate to it via URL.
+ *
+ * **Usage**
+ *
+ * Combine it with {@link VisualRegressionWrapper} component to make sure all visual regression stories have the same layout
+ *
+ * ```ts
+ * export const Visual = createVisualRegressionStory(() => (
+ *   <VisualRegressionWrapper>
+ *     <MyComponent state="default" />
+ *     <MyComponent state="special" />
+ *     <MyComponent state="special2" />
+ *     <MyComponent state="special3" />
+ *   </VisualRegressionWrapper>
+ * ));
+ * ```
+ *
+ * @remarks By starting your story's name with "visual" it is still tested by Chromatic, but not visible in the side bar. You can still navigate to it through the URL.
+ *
+ * @see {@link VisualRegressionWrapper}
+ * @param render function which renders the story's body
+ * @returns a storybook story
+ */
 export const createVisualRegressionStory: CreateVisualRegressionStoryFn = (
   render: VisualRegressionRenderFn,
 ): StoryObj => {
@@ -29,7 +53,16 @@ export const createVisualRegressionStory: CreateVisualRegressionStoryFn = (
   };
 };
 
-export const VisualRegressionWrapper = ({ children }: PropsWithChildren) => {
+/**
+ * Create an HTML flex container so every visual regression story has the same layout
+ *
+ * Use together with #createVisualRegressionStory
+ *
+ * @see {@link createVisualRegressionStory} on how to use it
+ * @param props {@link React.PropsWithChildren}
+ * @returns A {@link React.ReactElement}
+ */
+export const VisualRegressionWrapper = ({ children }: PropsWithChildren): React.ReactElement => {
   const wrapperStyle: CSSProperties = {
     backgroundColor: '',
     display: 'flex',

--- a/packages/storybook/src/web-components/button-login/button-login.stories.tsx
+++ b/packages/storybook/src/web-components/button-login/button-login.stories.tsx
@@ -5,6 +5,9 @@ import type { JSX } from '@lux/web-components-stencil';
 import type { Meta, StoryObj } from '@storybook/react';
 import { PropsWithoutRef } from 'react';
 import readme from './button-login.md?raw';
+import { VisualAgents } from './visual/Agents';
+import { VisualStates } from './visual/States';
+import { createVisualRegressionStory, VisualRegressionWrapper } from '../../utils/createVisualRegressionStory';
 
 const LuxButtonLogin = (props: PropsWithoutRef<JSX.LuxButtonLogin>) => <ButtonLogin {...props} />;
 
@@ -44,3 +47,10 @@ export const Playground: Story = {
     agent: 'digid',
   },
 };
+
+export const Visual = createVisualRegressionStory(() => (
+  <VisualRegressionWrapper>
+    <VisualAgents />
+    <VisualStates />
+  </VisualRegressionWrapper>
+));

--- a/packages/storybook/src/web-components/button-login/inlogstraat.mdx
+++ b/packages/storybook/src/web-components/button-login/inlogstraat.mdx
@@ -1,6 +1,6 @@
 import { Markdown, Meta } from "@storybook/blocks";
 import markdown from "../../patterns/inlogstraat.md?raw";
 
-<Meta title="Web Components/Button login/Inlogstraat" name="Inlogstraat" />
+<Meta title="Web Components/Button login/Interactieve stijlgids" />
 
 <Markdown>{markdown}</Markdown>

--- a/packages/storybook/src/web-components/button-login/visual/Agents.tsx
+++ b/packages/storybook/src/web-components/button-login/visual/Agents.tsx
@@ -1,0 +1,11 @@
+import { LuxButtonLogin } from '@lux/web-components-react';
+
+export const VisualAgents = () => (
+  <>
+    <h4 className="lux-heading-4">Agents</h4>
+    <LuxButtonLogin agent="digid"></LuxButtonLogin>
+    <LuxButtonLogin agent="digid-machtigen"></LuxButtonLogin>
+    <LuxButtonLogin agent="eherkenning"></LuxButtonLogin>
+    <LuxButtonLogin agent="eidas"></LuxButtonLogin>
+  </>
+);

--- a/packages/storybook/src/web-components/button-login/visual/States.tsx
+++ b/packages/storybook/src/web-components/button-login/visual/States.tsx
@@ -1,0 +1,10 @@
+import { LuxButtonLogin } from '@lux/web-components-react';
+
+export const VisualStates = () => (
+  <>
+    <h4 className="lux-heading-4">States</h4>
+    <LuxButtonLogin agent="digid" label="Hover" class="force-state--hover"></LuxButtonLogin>
+    <LuxButtonLogin agent="digid" label="Active" class="force-state--active"></LuxButtonLogin>
+    <LuxButtonLogin agent="digid" label="Focus" class="force-state--focus"></LuxButtonLogin>
+  </>
+);

--- a/packages/web-components-stencil/src/components/button-login/button-login.tsx
+++ b/packages/web-components-stencil/src/components/button-login/button-login.tsx
@@ -29,7 +29,7 @@ export class ButtonLogin {
   @Element() el!: HTMLLuxButtonLoginElement;
 
   @Prop() public readonly agent!: ButtonLoginAgent;
-  @Prop() public readonly label!: string;
+  @Prop() public readonly label?: string;
 
   @Event() private luxClick!: EventEmitter<void>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
         specifier: 8.0.8
         version: 8.0.8(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
+      '@chromatic-com/storybook':
+        specifier: 1.3.3
+        version: 1.3.3(react@18.2.0)
       '@lux/assets':
         specifier: workspace:*
         version: link:../../proprietary/assets
@@ -273,6 +276,9 @@ importers:
         specifier: 8.0.8
         version: 8.0.8
       '@storybook/addon-actions':
+        specifier: 8.0.8
+        version: 8.0.8
+      '@storybook/addon-backgrounds':
         specifier: 8.0.8
         version: 8.0.8
       '@storybook/addon-docs':
@@ -317,6 +323,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.2.1
         version: 4.2.1(vite@5.2.9)
+      chromatic:
+        specifier: 11.3.0
+        version: 11.3.0
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1915,6 +1924,21 @@ packages:
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@chromatic-com/storybook@1.3.3(react@18.2.0):
+    resolution: {integrity: sha512-1y9r691T5vVGDZ0HY3YrCXUnvtrT2YrhDuvDZSvYSNUVpM/Imz6i1dnNMKb3eoI1qRsH55mI4zCt+Iq94NLedQ==}
+    engines: {node: '>=16.0.0', yarn: '>=1.22.18'}
+    dependencies:
+      chromatic: 11.3.0
+      filesize: 10.1.1
+      jsonfile: 6.1.0
+      react-confetti: 6.1.0(react@18.2.0)
+      strip-ansi: 7.1.0
+    transitivePeerDependencies:
+      - '@chromatic-com/cypress'
+      - '@chromatic-com/playwright'
+      - react
     dev: true
 
   /@colors/colors@1.5.0:
@@ -3578,6 +3602,14 @@ packages:
       dequal: 2.0.3
       polished: 4.2.2
       uuid: 9.0.1
+    dev: true
+
+  /@storybook/addon-backgrounds@8.0.8:
+    resolution: {integrity: sha512-lrAJjVxDeXSK116rDajb56TureZiT76ygraP22/IvU3IcWCEcRiKYwlay8WgCTbJHtFmdBpelLBapoT46+IR9Q==}
+    dependencies:
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      ts-dedent: 2.2.0
     dev: true
 
   /@storybook/addon-controls@8.0.8(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
@@ -6204,6 +6236,19 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /chromatic@11.3.0:
+    resolution: {integrity: sha512-q1ZtJDJrjLGnz60ivpC16gmd7KFzcaA4eTb7gcytCqbaKqlHhCFr1xQmcUDsm14CK7JsqdkFU6S+JQdOd2ZNJg==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+    dev: true
+
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
@@ -8186,6 +8231,11 @@ packages:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
     dependencies:
       minimatch: 5.1.6
+    dev: true
+
+  /filesize@10.1.1:
+    resolution: {integrity: sha512-L0cdwZrKlwZQkMSFnCflJ6J2Y+5egO/p3vgRSDQGxQt++QbUZe5gMbRO6kg6gzwQDPvq2Fk9AmoxUNfZ5gdqaQ==}
+    engines: {node: '>= 10.4.0'}
     dev: true
 
   /filesize@6.4.0:
@@ -13374,6 +13424,16 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
+  /react-confetti@6.1.0(react@18.2.0):
+    resolution: {integrity: sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      react: ^16.3.0 || ^17.0.1 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      tween-functions: 1.2.0
+    dev: true
+
   /react-docgen-typescript@2.2.2(typescript@5.4.5):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
@@ -15276,6 +15336,10 @@ packages:
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /tween-functions@1.2.0:
+    resolution: {integrity: sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==}
     dev: true
 
   /type-check@0.4.0:


### PR DESCRIPTION
Dingen om op te letten:
- de pipeline faalt. Dit is eerste opzet, dus die moet nog gefixt worden
- ik heb een achtergrond toegevoegd voor alle stories. Voor de visual regression stories gebruik ik een vast patroon als achtergrond. Dit laat duidelijker zien waar de randen en achtergronden (boundaries) van het component zich bevinden
- de visual regression story heet "Visual". Deze wil ik proberen uit het zijmenu te halen omdat het voor onze eindgebruikers niet van belangrijk is om te zien.
- momenteel staan zowel `light` als `dark` mode in een enkele story. Dat gaan we later oplossen door een keuze te bieden. 