### PR TITLE
build: pin GitHub Actions using hashes

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -12,20 +12,20 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
   lint:
@@ -34,24 +34,22 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: lint"
-        run: |
-          pnpm run --if-present lint
+        run: pnpm run --if-present lint
 
   build:
     runs-on: ubuntu-latest
@@ -59,43 +57,39 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: "Continuous Integration: lint build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present lint-build
+        run: pnpm run --if-present lint-build
 
       - name: "Continuous Integration: test build"
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present test-build
+        run: pnpm run --if-present test-build
 
       - name: "Publish to Chromatic"
-        uses: chromaui/action@v11
+        uses: chromaui/action@57a72947e9d7a6d213906cd506276c707e0c580f # v11.4.0
         if: |
           github.event.pull_request.draft == false &&
           github.actor != 'dependabot[bot]'
@@ -105,7 +99,7 @@ jobs:
           storybookBuildDir: packages/storybook/dist/
 
       - name: "Retain build artifact: storybook"
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: storybook
           path: packages/storybook/dist/
@@ -117,24 +111,22 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: test"
-        run: |
-          pnpm run --if-present test
+        run: pnpm run --if-present test
 
   publish-website:
     runs-on: ubuntu-latest
@@ -143,16 +135,16 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: "Restore build artifact: Storybook"
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: storybook
           path: packages/storybook/dist/
 
       - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@5c6e9e9f3672ce8fd37b9856193d2a537941e66c # v4.6.1
         with:
           branch: gh-pages
           folder: packages/storybook/dist/
@@ -164,26 +156,25 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           token: ${{ secrets.GH_TOKEN }}
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
 
       - name: "Continuous Deployment: install"
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
       - name: "Continuous Deployment: build"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:


### PR DESCRIPTION
Pin GitHub actions to their latest versions using hashes to prevent tampering. Tags are added as comments. Dependabot will update both hashes and comments in pull requests.

Add `--frozen-lockfile` to `pnpm install` to make it explicit that this is how pnpm runs in CI.