### PR TITLE
Heading stijling update

### DIFF
--- a/.changeset/ten-avocados-agree.md
+++ b/.changeset/ten-avocados-agree.md
@@ -1,0 +1,11 @@
+---
+"@lux-design-system/design-tokens": major
+---
+
+In deze commit:
+
+- Gewijzigde tokens:
+  - utrecht heading-1: color van `brand` naar `foreground`, font-weight van `bold` naar `regular`
+  - utrecht heading-3: color van `brand` naar `foreground`
+
+**Let op:** visuele wijziging op alle thema's, H1 en H3 hebben nu een andere vormgeving.

--- a/proprietary/design-tokens/src/imported/nl/utrecht-heading.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-heading.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "heading-1": {
       "color": {
-        "value": "{lux.color.brand.default}",
+        "value": "{lux.color.foreground.default}",
         "type": "color"
       },
       "font-family": {
@@ -10,7 +10,7 @@
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{lux.font-weight.bold}",
+        "value": "{lux.font-weight.regular}",
         "type": "fontWeights"
       },
       "line-height": {
@@ -46,7 +46,7 @@
     },
     "heading-3": {
       "color": {
-        "value": "{lux.color.brand.default}",
+        "value": "{lux.color.foreground.default}",
         "type": "color"
       },
       "font-family": {


### PR DESCRIPTION
# Contents

Wijziging tokens: Stijling van het heading component

Jesse heeft volgende aangevraagd:
H1, regular, zwart
H2, bold, brand
H3, bold, zwart
H4, bold, brand

<!--  Surround an item with double tildes `~~` to indicate that it does not apply to this PR -->

- ~~[ ] New features/components and bugfixes are covered by tests~~
- [x] Changesets are created
- ~~[ ] Definition of Done is checked~~
