### PR TITLE
focus styles linken naar common

### DIFF
--- a/.changeset/boom-groen-kaal.md
+++ b/.changeset/boom-groen-kaal.md
@@ -1,0 +1,5 @@
+---
+'@lux-design-system/design-tokens': patch
+---
+
+Wijzig tokens: hover en focus tokens van de inputs gelijk getrokken

--- a/proprietary/design-tokens/src/imported/nl/utrecht-checkbox.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-checkbox.json
@@ -188,15 +188,15 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{lux.checkbox.checked.active.background-color}",
+            "value": "{lux.color.brand.hover}",
             "type": "color"
           },
           "border-color": {
-            "value": "{lux.checkbox.checked.active.border-color}",
+            "value": "{lux.color.border.strong}",
             "type": "color"
           },
           "color": {
-            "value": "{lux.checkbox.checked.active.color}",
+            "value": "{lux.color.wit}",
             "type": "color"
           }
         },
@@ -206,15 +206,15 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{lux.checkbox.checked.hover.background-color}",
+            "value": "{lux.color.brand.hover}",
             "type": "color"
           },
           "border-color": {
-            "value": "transparent",
+            "value": "{lux.color.border.strong}",
             "type": "color"
           },
           "color": {
-            "value": "{lux.checkbox.checked.hover.color}",
+            "value": "{lux.color.wit}",
             "type": "color"
           }
         },
@@ -224,29 +224,29 @@
             "type": "borderWidth"
           },
           "background-color": {
-            "value": "{lux.checkbox.checked.focus.background-color}",
+            "value": "{lux.color.brand.default}",
             "type": "color"
           },
           "border-color": {
-            "value": "{lux.checkbox.checked.focus.border-color}",
+            "value": "{lux.color.border.strong}",
             "type": "color"
           },
           "color": {
-            "value": "{lux.checkbox.checked.focus.color}",
+            "value": "{lux.color.wit}",
             "type": "color"
           }
         },
         "disabled": {
           "background-color": {
-            "value": "{lux.checkbox.checked.disabled.background-color}",
+            "value": "{lux.color.background.subdued}",
             "type": "color"
           },
           "border-color": {
-            "value": "{lux.checkbox.checked.disabled.border-color}",
+            "value": "{lux.color.border.subdued}",
             "type": "color"
           },
           "color": {
-            "value": "{lux.checkbox.checked.disabled.color}",
+            "value": "{lux.color.foreground.subdued}",
             "type": "color"
           }
         }
@@ -258,15 +258,15 @@
       "checked": {
         "focus": {
           "background-color": {
-            "value": "{utrecht.checkbox.checked.background-color}",
+            "value": "{lux.color.brand.default}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.checkbox.checked.border-color}",
+            "value": "{lux.color.border.strong}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.checkbox.checked.color}",
+            "value": "{lux.color.wit}",
             "type": "color"
           }
         },

--- a/proprietary/design-tokens/src/imported/nl/utrecht-radio-button.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-radio-button.json
@@ -101,15 +101,15 @@
       },
       "focus": {
         "background-color": {
-          "value": "{utrecht.radio-button.background-color}",
+          "value": "{lux.color.background.default}",
           "type": "color"
         },
         "border-color": {
-          "value": "{utrecht.radio-button.border-color}",
+          "value": "{lux.color.foreground.default}",
           "type": "color"
         },
         "color": {
-          "value": "{utrecht.radio-button.focus.border-color}",
+          "value": "{lux.color.foreground.default}",
           "type": "color"
         },
         "border-width": {
@@ -168,15 +168,15 @@
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.radio-button.checked.background-color}",
+            "value": "{lux.color.background.default}",
             "type": "color"
           },
           "border-color": {
-            "value": "{utrecht.radio-button.checked.border-color}",
+            "value": "{lux.color.foreground.default}",
             "type": "color"
           },
           "color": {
-            "value": "{utrecht.radio-button.checked.color}",
+            "value": "{lux.color.foreground.default}",
             "type": "color"
           },
           "border-width": {

--- a/proprietary/design-tokens/src/imported/nl/utrecht-text-input.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-text-input.json
@@ -86,10 +86,6 @@
         "type": "borderWidth"
       },
       "focus": {
-        "border-width": {
-          "value": "{lux.border-width.m}",
-          "type": "borderWidth"
-        },
         "background-color": {
           "value": "{lux.color.background.default}",
           "type": "color"
@@ -131,15 +127,25 @@
           "type": "color"
         }
       },
-      "hover": {
+      "min-block-size": {
+        "value": "{lux.size.target}",
+        "type": "sizing"
+      }
+    }
+  },
+  "lux": {
+    "textbox": {
+      "focus": {
         "border-width": {
           "value": "{lux.border-width.m}",
           "type": "borderWidth"
         }
       },
-      "min-block-size": {
-        "value": "{lux.size.target}",
-        "type": "sizing"
+      "hover": {
+        "border-width": {
+          "value": "{lux.border-width.m}",
+          "type": "borderWidth"
+        }
       }
     }
   },

--- a/proprietary/design-tokens/src/imported/nl/utrecht-text-input.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-text-input.json
@@ -133,7 +133,7 @@
       },
       "hover": {
         "border-width": {
-          "value": "{lux.border-width.default}",
+          "value": "{lux.border-width.m}",
           "type": "borderWidth"
         }
       },

--- a/proprietary/design-tokens/src/imported/nl/utrecht-textarea.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-textarea.json
@@ -69,10 +69,6 @@
         "color": {
           "value": "{lux.color.foreground.default}",
           "type": "color"
-        },
-        "border-width": {
-          "value": "{lux.border-width.m}",
-          "type": "borderWidth"
         }
       },
       "disabled": {
@@ -115,10 +111,6 @@
         "color": {
           "value": "{lux.color.foreground.default}",
           "type": "color"
-        },
-        "border-width": {
-          "value": "{lux.border-width.m}",
-          "type": "borderWidth"
         }
       },
       "border-radius": {
@@ -148,6 +140,26 @@
       "font-size": {
         "value": "{lux.font-size.body.default}",
         "type": "fontSizes"
+      },
+      "min-block-size": {
+        "value": "{lux.size.target}",
+        "type": "sizing"
+      }
+    }
+  },
+  "lux": {
+    "textarea": {
+      "focus": {
+        "border-width": {
+          "value": "{lux.border-width.m}",
+          "type": "borderWidth"
+        }
+      },
+      "hover": {
+        "border-width": {
+          "value": "{lux.border-width.m}",
+          "type": "borderWidth"
+        }
       }
     }
   }

--- a/proprietary/design-tokens/src/imported/nl/utrecht-textarea.json
+++ b/proprietary/design-tokens/src/imported/nl/utrecht-textarea.json
@@ -117,7 +117,7 @@
           "type": "color"
         },
         "border-width": {
-          "value": "{lux.border-width.default}",
+          "value": "{lux.border-width.m}",
           "type": "borderWidth"
         }
       },


### PR DESCRIPTION
# Contents

**Wijziging tokens**: 
- component focus styles van radio en checkbox niet naar de default variant maar naar de common laag gelinkt. Dit zodat de juiste variables in Figma worden toegekend. Heeft geen invloed op de stijling of code. 
- De hover border-width van text input en textarea naar 2px gezet, net als bij de select.
- De prefix van de hover en border-width tokens van de text input en textarea veranderd van utrecht naar lux. Dit is gelijk naar hoe we dit bij select hebben opgelost.

## Checklist

<!--  Surround an item with double tildes `~~` to indicate that it does not apply to this PR -->

- [ ] New features/components and bugfixes are covered by tests
- [ ] Changesets are created
- [ ] Definition of Done is checked
