### PR TITLE
fix(459): Remove test files from tsconfig exclude so they are being interpreted by Typescript

### DIFF
--- a/.changeset/two-swans-reply.md
+++ b/.changeset/two-swans-reply.md
@@ -1,0 +1,5 @@
+---
+"@lux-design-system/components-react": patch
+---
+
+Remove test files from tsconfig exclude so they are being interpreted by Typescript

--- a/packages/components-react/tsconfig.json
+++ b/packages/components-react/tsconfig.json
@@ -22,5 +22,5 @@
     "target": "es2020"
   },
   "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/index.ts", "vite.config.ts"],
-  "exclude": ["**/node_modules/*", "**/*.test.ts", "src/**/*.test.tsx", "**/*.spec.ts", "src/**/*.spec.tsx"]
+  "exclude": ["**/node_modules/*"]
 }


### PR DESCRIPTION
Remove test files from tsconfig exclude so they are being interpreted by Typescript

# Contents

<!-- Description of what this PR contains. New components/features, bugfixes, etc. -->

## Checklist

<!--  Surround an item with double tildes `~~` to indicate that it does not apply to this PR -->

- [ ] New features/components and bugfixes are covered by tests
- [ ] Changesets are created
- [ ] Definition of Done is checked
