### PR TITLE
Run lint-staged from local node_modules, not global

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
I had some errors with mismatched node versions.  This repo uses 20.16, but my locally installed lint-staged requires 20.17+.  The repo should not rely on or use globally-installed packages.
