### PR TITLE
ci: opt in to pnpm v11 for pnpm audit with an environment variable

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -23,6 +23,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+      
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -49,6 +56,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+      
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -112,6 +126,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+      
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -163,6 +184,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+      
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical


### PR DESCRIPTION
This PR updates the pnpm audit command to use the v11 version of the command.

It only affects the pnpm audit command, and does not affect the other pnpm commands like pnpm install.
You have to opt in to this by setting the `ENABLE_PNPM_AUDIT_V11` environment variable to `1`.
You can choose to do this on the repository level or on the organization level.

See https://github.com/nl-design-system/beheer/issues/70 for more details.