### PR TITLE
Doubly ensure packages are published with provenance

### DIFF
--- a/.changeset/poor-lizards-help.md
+++ b/.changeset/poor-lizards-help.md
@@ -1,0 +1,11 @@
+---
+"@lux-design-system/lux-community-components-react": patch
+"@lux-design-system/lux-community-design-tokens": patch
+"@lux-design-system/web-components-stencil": patch
+"@lux-design-system/web-components-react": patch
+"@lux-design-system/components-react": patch
+"@lux-design-system/design-tokens": patch
+"@lux-design-system/font": patch
+---
+
+This is not strictly necessary, because there are other ways to configure provenance (notably .npmrc), but it helps with automated scripts and gives extra peace of mind.

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -10,7 +10,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/lux-community-components-react/package.json
+++ b/packages/lux-community-components-react/package.json
@@ -10,7 +10,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/web-components-react/package.json
+++ b/packages/web-components-react/package.json
@@ -10,7 +10,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/web-components-stencil/package.json
+++ b/packages/web-components-stencil/package.json
@@ -10,7 +10,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -10,7 +10,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "lib/",

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -11,7 +11,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "dist"

--- a/proprietary/lux-community-design-tokens/package.json
+++ b/proprietary/lux-community-design-tokens/package.json
@@ -10,7 +10,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "dist/"


### PR DESCRIPTION
This is not strictly necessary, because there are other ways to configure provenance (notably .npmrc), but it helps with automated scripts and gives extra peace of mind.
