### PR TITLE
chore: upgrade pnpm to 11

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -23,13 +23,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -56,13 +49,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -126,13 +112,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -184,13 +163,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-      
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,6 @@
-engine-strict=true
-save-prefix=
-strict-peer-dependencies=false
-auto-install-peers=false
+# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
+# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
+# pnpm approve-builds
+ignore-scripts=true
+
 @jsr:registry=https://npm.jsr.io

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "engines": {
     "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
+    "pnpm": "^11.4.0"
   },
   "repository": {
     "type": "git+ssh",
@@ -82,10 +82,5 @@
   "dependencies": {
     "http-server": "14.1.1"
   },
-  "pnpm": {
-    "patchedDependencies": {
-      "@tokens-studio/sd-transforms@0.15.2": "patches/@tokens-studio__sd-transforms@0.15.2.patch"
-    }
-  },
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a"
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,7 @@ overrides:
   shell-quote@>=1.1.0 <=1.8.3: '>=1.8.4'
 
 patchedDependencies:
-  '@tokens-studio/sd-transforms@0.15.2':
-    hash: 9cc9f75669c0c4d3d97f6be55c6b06c1b2e465ba82ee06f2eaa9f671489303bc
-    path: patches/@tokens-studio__sd-transforms@0.15.2.patch
+  '@tokens-studio/sd-transforms@0.15.2': 9cc9f75669c0c4d3d97f6be55c6b06c1b2e465ba82ee06f2eaa9f671489303bc
 
 importers:
 
@@ -3560,6 +3558,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@utrecht/accordion-css@1.6.0':
     resolution: {integrity: sha512-0PLGWCgRvFyR8kINBE4v8dsQxxdfKbmC5oEolOF2jGJ7NlmeTE29ODAzlcqwiocWOjM45jgXDK8aRVAle2DObg==}
@@ -5469,6 +5468,7 @@ packages:
   glob@10.4.1:
     resolution: {integrity: sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==}
     engines: {node: '>=16 || 14 >=14.18'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@10.4.5:
@@ -8167,6 +8167,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telejson@7.2.0:
     resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
@@ -8547,6 +8548,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,11 @@ packages:
   - "packages/*"
   - "proprietary/*"
 
+allowBuilds:
+  '@bundled-es-modules/glob': true
+  esbuild: true
+  style-dictionary: true
+
 # Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
 autoInstallPeers: false
 
@@ -43,3 +48,6 @@ savePrefix: ""
 
 # Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
 strictPeerDependencies: false
+
+patchedDependencies:
+  '@tokens-studio/sd-transforms@0.15.2': patches/@tokens-studio__sd-transforms@0.15.2.patch


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  pnpm 11 has been out for a while now, and is now the recommended version to use.  Set the minimum version to 11.4 since that is the latest version with security fixes.  To use pnpm 11, ensure you're on a recent version of Node and run `corepack enable` in the root of the repository.

```sh
# to use the version of pnpm as specified in package.json
corepack enable
```

[pnpm 11](https://pnpm.io/blog/releases/11.0#highlights) comes with breaking changes and the [migration guide](https://pnpm.io/migration) was used.  It comes with better defaults for [strictDepBuilds](https://pnpm.io/settings#strictdepbuilds): you must now explicitly review which build scripts are allowed.  As well as `blockExoticSubdeps`.

The automigration moved all properties from `.npmrc` to `pnpm-workspace.yaml`, but we want to keep `ignore-scripts` as a safety measure and `provenance` because changeset publish bypasses pnpm.

`minimumReleaseAge` by default is now 24h, same as our existing setting.  I still kept it in `pnpm-workspace.yaml`, as it doesn't hurt to be explicit about it.

Also cleaned up the workaround in pipelines that allowed an RC version of pnpm to be used when the npm audit endpoint was down.  With pnpm 11, this is no longer needed.
