### PR TITLE
ci: rerun workflow when marking PRs as ready for review

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # opened, synchronize, reopened are default; ready_for_review is needed to
+      # run steps that are skipped in draft PRs.
+      - ready_for_review
 
 permissions: {}
 


### PR DESCRIPTION
This fixes a potential issue where Chromatic (a required check) is not run.  Specifically, when a Draft PR is marked as ready for review, the workflow is not rerun.  Since the check is required, the PR would not be mergeable even with the required approvals.
